### PR TITLE
Change :association to :each_with_index

### DIFF
--- a/lib/json_rspec_match_maker/base.rb
+++ b/lib/json_rspec_match_maker/base.rb
@@ -67,29 +67,42 @@ module JsonRspecMatchMaker
     def check_json_against_instance
       raise MatchDefinitionNotFound, self.class.name unless @match_definition
       @match_definition.each do |error_key, match_def|
-        if match_def[:association].nil?
+        if match_def[:each_with_index].nil?
           check_values(error_key, match_def)
         else
-          check_association(error_key, match_def)
+          check_each(error_key, match_def)
         end
       end
     end
 
-    # Iterates through an association of the instance while checking fields
+    # Iterates through a list of objects while checking fields
     # @api private
+    # @param error_key [String]
+    #   the first name of the field reported in the error
+    #   each errors are reported #{error_key}[#{idx}].#{each_key}
+    # @param each_definition [Hash]
+    #   :each_with_index is a function that returns the list of items
+    #   :attributes is a hash with the same structure as the top-level match_def hash
     # @return [nil] returns nothing, adds to error list as side effect
-    def check_association(error_key, association_definition)
-      association = association_definition[:association].call(instance)
-      association.each_with_index do |associated_instance, idx|
-        association_definition[:attributes].each do |attr_error_key, match_functions|
+    def check_each(error_key, each_definition)
+      enumerable = each_definition[:each_with_index].call(instance)
+      enumerable.each_with_index do |each_instance, idx|
+        each_definition[:attributes].each do |attr_error_key, match_functions|
           full_error_key = "#{error_key}[#{idx}].#{attr_error_key}"
-          check_values(full_error_key, match_functions, associated_instance, idx)
+          check_values(full_error_key, match_functions, each_instance, idx)
         end
       end
     end
 
     # Checks fields on a single instance
     # @api private
+    # @param error_key [String] the name of the field reported in the error
+    # @param match_functions [Hash]
+    #  :instance is a function returning the value for the key for the object being serialized
+    #  :json is a function returning the value for the key for the json
+    # @param expected_instance [Object]
+    #   the top level instance, or an each instance from #check_each
+    # @param idx [nil, Integer] the index if iterating through a list, otherwise nil
     # @return [nil] returns nothing, adds to error list as side effect
     def check_values(error_key, match_functions, expected_instance = instance, idx = nil)
       instance_value = match_functions[:instance].call(expected_instance)

--- a/spec/subclass_matcher_spec.rb
+++ b/spec/subclass_matcher_spec.rb
@@ -17,7 +17,7 @@ class ExampleMatcher < JsonRspecMatchMaker::Base
       json: ->(json) { json['name'] }
     },
     'association' => {
-      association: ->(instance) { instance.association },
+      each_with_index: ->(instance) { instance.association },
       attributes: {
         'id' => {
           instance: ->(instance) { instance.id },


### PR DESCRIPTION
- Makes this less specific to active record and associations
- Makes more sense for top-level arrays
- Makes it more obvious why the json functions within the attributes key
  take an index as a second argument