### PR TITLE
Refactored to be more robust and rspec like

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ GEM
     coderay (1.1.2)
     diff-lcs (1.3)
     method_source (0.9.0)
-    minitest (5.11.3)
     parallel (1.12.1)
     parser (2.5.0.3)
       ast (~> 2.4.0)
@@ -52,7 +51,6 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.16)
   json_rspec_match_maker!
-  minitest (~> 5.0)
   pry
   rake (~> 10.0)
   rspec (~> 3.7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,12 +7,17 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
+    coderay (1.1.2)
     diff-lcs (1.3)
+    method_source (0.9.0)
     minitest (5.11.3)
     parallel (1.12.1)
     parser (2.5.0.3)
       ast (~> 2.4.0)
     powerpack (0.1.1)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     rainbow (3.0.0)
     rake (10.5.0)
     rspec (3.7.0)
@@ -48,6 +53,7 @@ DEPENDENCIES
   bundler (~> 1.16)
   json_rspec_match_maker!
   minitest (~> 5.0)
+  pry
   rake (~> 10.0)
   rspec (~> 3.7.0)
   rubocop (~> 0.52.1)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Write RSpec matchers for JSON api endpoints using a simple data structure.
 DRY up API expectations, without losing the specificity sacrificed by a
 schema-based approach to JSON expectations.
 
+## Why?
+
+
+
 ## Installation with Rails
 
 Add this line to your application's Gemfile:

--- a/README.md
+++ b/README.md
@@ -249,8 +249,8 @@ Arrays are defined very similary to single objects:
   'answers' => {
     each: ->(instance) { instance.answers },
     attributes: {
-      'id' => ->(instance) { instance.id },
-      'question' => ->(instance) { instance.question.text },
+      'id' => ->(answer) { answer.id },
+      'question' => ->(answer) { answer.question.text },
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -242,12 +242,12 @@ class AddressMatcher < JsonRspecMatchMaker::Base
 end
 ```
 
-Associations are defined very similarly to top level attributes:
+Arrays are defined very similary to single objects:
 
 ```ruby
 {
   'answers' => {
-    association: ->(instance) { instance.answers },
+    each: ->(instance) { instance.answers },
     attributes: {
       'id' => ->(instance) { instance.id },
       'question' => ->(instance) { instance.question.text },

--- a/README.md
+++ b/README.md
@@ -90,34 +90,13 @@ Here is an example of a complete matcher class:
 ```ruby
 class AddressMatcher < JsonRspecMatchMaker::Base
   MATCH_DEF = {
-    'id' => {
-      instance: ->(instance) { instance.id },
-      json: ->(json) { json['id'] }
-    },
-    'description' => {
-      instance: ->(instance) { instance.description },
-      json: ->(json) { json['description'] }
-    },
-    'street_line_one' => {
-       instance: ->(instance) { instance.street_line_one },
-       json: ->(json) { json['address']['street_line_one'] }
-    },
-    'street_line_two' => {
-      instance: ->(instance) { instance.street_line_two },
-      json: ->(json) { json['address']['street_line_two'] }
-    },
-    'city' => {
-      instance: ->(instance) { instance.city },
-      json: ->(json) { json['address']['city'] }
-    },
-    'state' => {
-      instance: ->(instance) { instance.state.abbreviation },
-      json: ->(json) { json['address']['state'] }
-    },
-    'postal_code' => {
-      instance: ->(instance) { instance.postal_code },
-      json: ->(json) { json['address']['postal_code'] }
-    }
+    'id' => ->(instance) { instance.id },
+    'description' => ->(instance) { instance.description },
+    'street_line_one' => ->(instance) { instance.street_line_one },
+    'street_line_two' => ->(instance) { instance.street_line_two },
+    'city' => ->(instance) { instance.city },
+    'state' => ->(instance) { instance.state.abbreviation },
+    'postal_code' => ->(instance) { instance.postal_code },
   }.freeze
 
   def initialize(address)
@@ -142,10 +121,7 @@ class AddressMatcher < JsonRspecMatchMaker::Base
   
   def set_match_def(state_format)
     {
-      'state' => {
-        instance: ->(instance) { instance.state.formatted(state_format) },
-        json: ->(json) { json['address']['state'] }
-      }
+      'state' => ->(instance) { instance.state.formatted(state_format) }
     }.merge(MATCH_DEF)
   end
 end
@@ -158,14 +134,8 @@ Associations are defined very similarly to top level attributes:
   'answers' => {
     association: ->(instance) { instance.answers },
     attributes: {
-      'id' => {
-        instance: ->(instance) { instance.id },
-        json: ->(json, idx) { json['answers'][idx]['id'] }
-      },
-      'question' => {
-        instance: ->(instance) { instance.question.text },
-        json: ->(json, idx) { json['answers'][idx]['question'] }
-      }
+      'id' => ->(instance) { instance.id },
+      'question' => ->(instance) { instance.question.text },
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -87,14 +87,14 @@ like for the same case:
 
 ```ruby
 {
-  'user.auth_token' => ->(user) { user.auth_token },
-  'user.created_at' => ->(user) { user.created_at },
-  'user.email' => ->(user) { user.email },
-  'user.first_name' => ->(user) { user.first_name },
-  'user.id' => ->(user) { user.id },
-  'user.last_name' => ->(user) { user.last_name }
+  'user.auth_token' =>   ->(user) { user.auth_token },
+  'user.created_at' =>   ->(user) { user.created_at },
+  'user.email' =>        ->(user) { user.email },
+  'user.first_name' =>   ->(user) { user.first_name },
+  'user.id' =>           ->(user) { user.id },
+  'user.last_name' =>    ->(user) { user.last_name }
   'user.phone_number' => ->(user) { user.phone_number },
-  'user.updated_at' => ->(user) { user.updated_at }
+  'user.updated_at' =>   ->(user) { user.updated_at }
 }
 ```
 

--- a/json_rspec_match_maker.gemspec
+++ b/json_rspec_match_maker.gemspec
@@ -1,5 +1,5 @@
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'json_rspec_match_maker/version'
 
@@ -21,10 +21,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.7.0'
   spec.add_development_dependency 'rubocop', '~> 0.52.1'
   spec.add_development_dependency 'yard', '~> 0.9.12'
   spec.add_development_dependency 'yardstick', '~> 0.9.9'
-  spec.add_development_dependency 'pry'
 end

--- a/json_rspec_match_maker.gemspec
+++ b/json_rspec_match_maker.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.16'
-  spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.7.0'
   spec.add_development_dependency 'rubocop', '~> 0.52.1'

--- a/json_rspec_match_maker.gemspec
+++ b/json_rspec_match_maker.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.52.1'
   spec.add_development_dependency 'yard', '~> 0.9.12'
   spec.add_development_dependency 'yardstick', '~> 0.9.9'
+  spec.add_development_dependency 'pry'
 end

--- a/lib/json_rspec_match_maker.rb
+++ b/lib/json_rspec_match_maker.rb
@@ -1,4 +1,6 @@
 require 'json_rspec_match_maker/version'
+require 'json_rspec_match_maker/expected_value'
+require 'json_rspec_match_maker/target_value'
 require 'json_rspec_match_maker/base'
 
 # Main point of interest is that this module includes a utility

--- a/lib/json_rspec_match_maker/base.rb
+++ b/lib/json_rspec_match_maker/base.rb
@@ -129,8 +129,13 @@ module JsonRspecMatchMaker
     # @api private
     # @return [String] the error message
     def add_error(field, expected_value, target_value)
-      @errors[field] =
-        "Mismatch in field #{field}: expected (#{expected_value}), got: (#{target_value})"
+      @errors[field] = <<-MSG
+
+        Mismatch in field: '#{field}'
+          expected: '#{expected_value}'
+          received: '#{target_value}'
+
+      MSG
     end
   end
 end

--- a/lib/json_rspec_match_maker/base.rb
+++ b/lib/json_rspec_match_maker/base.rb
@@ -14,12 +14,12 @@ module JsonRspecMatchMaker
     # The object being expected against
     # @api private
     # @return [Object]
-    attr_reader :instance
+    attr_reader :expected
 
     # The json being tested
     # @api private
     # @return [Hash]
-    attr_reader :json
+    attr_reader :target
 
     # Data structure that specifies how instance values relate to JSON values
     # @api private
@@ -28,12 +28,12 @@ module JsonRspecMatchMaker
 
     # Create a new JSON matcher
     # @api public
-    # @param instance [Object] The object being serialized into JSON
+    # @param expected [Object] The object being serialized into JSON
     # @example
     #   JsonRspecMatchMaker.new(active_record_model)
     #   JsonRspecMatchMaker.new(presenter_instance)
-    def initialize(instance)
-      @instance = instance
+    def initialize(expected)
+      @expected = expected
       @errors = {}
     end
 
@@ -43,9 +43,9 @@ module JsonRspecMatchMaker
     # @example
     #   JsonRspecMatchMaker.new(user).matches?(user.to_json) #=> true
     #   JsonRspecMatchMaker.new(dog).matches?(cat.to_json) #=> false
-    def matches?(json)
-      @json = json
-      check_json_against_instance
+    def matches?(target)
+      @target = target
+      check_target_against_expected
       @errors.empty?
     end
 
@@ -64,10 +64,10 @@ module JsonRspecMatchMaker
     # @api private
     # @raise [MatchDefinitionNotFound] if child class does not set @match_definition
     # @return [nil] returns nothing, adds to error list as side effect
-    def check_json_against_instance
+    def check_target_against_expected
       raise MatchDefinitionNotFound, self.class.name unless @match_definition
       @match_definition.each do |error_key, match_def|
-        if match_def[:each_with_index].nil?
+        if match_def.respond_to? :call
           check_values(error_key, match_def)
         else
           check_each(error_key, match_def)
@@ -81,15 +81,15 @@ module JsonRspecMatchMaker
     #   the first name of the field reported in the error
     #   each errors are reported #{error_key}[#{idx}].#{each_key}
     # @param each_definition [Hash]
-    #   :each_with_index is a function that returns the list of items
+    #   :each is a function that returns the list of items
     #   :attributes is a hash with the same structure as the top-level match_def hash
     # @return [nil] returns nothing, adds to error list as side effect
     def check_each(error_key, each_definition)
-      enumerable = each_definition[:each_with_index].call(instance)
+      enumerable = each_definition[:each].call(expected)
       enumerable.each_with_index do |each_instance, idx|
-        each_definition[:attributes].each do |attr_error_key, match_functions|
-          full_error_key = "#{error_key}[#{idx}].#{attr_error_key}"
-          check_values(full_error_key, match_functions, each_instance, idx)
+        each_definition[:attributes].each do |attr_error_key, match_function|
+          each_opts = { idx: idx, error_key: attr_error_key }
+          check_values(error_key, match_function, each_instance, each_opts)
         end
       end
     end
@@ -97,29 +97,40 @@ module JsonRspecMatchMaker
     # Checks fields on a single instance
     # @api private
     # @param error_key [String] the name of the field reported in the error
-    # @param match_functions [Hash]
-    #  :instance is a function returning the value for the key for the object being serialized
-    #  :json is a function returning the value for the key for the json
+    # @param match_function [Hash]
+    #   a function returning the value for the key for the object being serialized
     # @param expected_instance [Object]
     #   the top level instance, or an each instance from #check_each
-    # @param idx [nil, Integer] the index if iterating through a list, otherwise nil
+    # @param each_opts [nil, Hash]
+    #  nil if checking a top level value
+    #  Hash if iterating through a list
+    #    :idx the current index
+    #    :error_key the subfield reported in the error
+    # the index if iterating through a list, otherwise nil
     # @return [nil] returns nothing, adds to error list as side effect
-    def check_values(error_key, match_functions, expected_instance = instance, idx = nil)
-      instance_value = match_functions[:instance].call(expected_instance)
-      json_value = if idx.nil?
-                     match_functions[:json].call(json)
-                   else
-                     match_functions[:json].call(json, idx)
-                   end
-      add_error(error_key, instance_value, json_value) if instance_value != json_value
+    def check_values(error_key, match_function, expected_instance = expected, each_opts = nil)
+      expected_value = match_function.call(expected_instance)
+      if each_opts.nil?
+        target_value = value_for_key(error_key, target)
+      else
+        targets = value_for_key(error_key, target)
+        specific_target = targets[each_opts[:idx]]
+        target_value = value_for_key(each_opts[:error_key], specific_target)
+        error_key = "#{error_key}[#{each_opts[:idx]}].#{each_opts[:error_key]}"
+      end
+      add_error(error_key, expected_value, target_value) if expected_value != target_value
+    end
+
+    def value_for_key(key, json)
+      key.split('.').reduce(json) { |j, k| j[k] }
     end
 
     # Adds an erorr to the list when a mismatch is detected
     # @api private
     # @return [String] the error message
-    def add_error(field, instance_value, json_value)
+    def add_error(field, expected_value, target_value)
       @errors[field] =
-        "Mismatch in field #{field}: expected (#{instance_value}), got: (#{json_value})"
+        "Mismatch in field #{field}: expected (#{expected_value}), got: (#{target_value})"
     end
   end
 end

--- a/lib/json_rspec_match_maker/expected_value.rb
+++ b/lib/json_rspec_match_maker/expected_value.rb
@@ -1,0 +1,14 @@
+module JsonRspecMatchMaker
+  # Handles fetching the expected value from the expected instance
+  class ExpectedValue
+    attr_reader :value
+    def initialize(match_function, expected_instance)
+      @value = match_function.call(expected_instance)
+    end
+
+    def ==(other)
+      raise ArgumentError unless other.is_a? TargetValue
+      other.value == value
+    end
+  end
+end

--- a/lib/json_rspec_match_maker/target_value.rb
+++ b/lib/json_rspec_match_maker/target_value.rb
@@ -1,0 +1,34 @@
+module JsonRspecMatchMaker
+  # Handles fetching the target value from the target object
+  class TargetValue
+    attr_reader :error_key, :value
+
+    def initialize(key, each_opts, target)
+      @error_key = full_error_key(key, each_opts)
+      @value = fetch_value(key, each_opts, target)
+    end
+
+    def full_error_key(key, each_opts)
+      return key if each_opts.nil?
+
+      "#{key}[#{each_opts[:idx]}].#{each_opts[:error_key]}"
+    end
+
+    def fetch_value(key, each_opts, target)
+      return value_for_key(key, target) if each_opts.nil?
+
+      targets = value_for_key(key, target)
+      specific_target = targets[each_opts[:idx]]
+      value_for_key(each_opts[:error_key], specific_target)
+    end
+
+    def value_for_key(key, json)
+      key.split('.').reduce(json) { |j, k| j[k] }
+    end
+
+    def ==(other)
+      raise ArgumentError unless other.is_a? ExpectedValue
+      other.value == value
+    end
+  end
+end

--- a/spec/lib/json_rspec_match_maker/base_spec.rb
+++ b/spec/lib/json_rspec_match_maker/base_spec.rb
@@ -3,19 +3,19 @@ require 'spec_helper'
 RSpec.describe JsonRspecMatchMaker::Base do
   Struct.new('Example', :id, :name, :description)
 
-  let(:instance) { Struct::Example.new(1, 'test', 'a test object') }
-  let(:matcher) { JsonRspecMatchMaker::Base.new(instance) }
-  let(:json) { { id: 1, name: 'test', description: 'a test object' } }
+  let(:expected) { Struct::Example.new(1, 'test', 'a test object') }
+  let(:matcher) { JsonRspecMatchMaker::Base.new(expected) }
+  let(:target) { { id: 1, name: 'test', description: 'a test object' } }
 
   describe '#initialize' do
     it 'is initialized with the instance being expected against' do
-      expect(matcher.instance).to eq instance
+      expect(matcher.expected).to eq expected
     end
   end
 
   describe '#matches?' do
     it 'raises an error if no @match_definition is set' do
-      expect { matcher.matches?(json) }.to raise_error JsonRspecMatchMaker::MatchDefinitionNotFound
+      expect { matcher.matches?(target) }.to raise_error JsonRspecMatchMaker::MatchDefinitionNotFound
     end
   end
 

--- a/spec/lib/json_rspec_match_maker/base_spec.rb
+++ b/spec/lib/json_rspec_match_maker/base_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe JsonRspecMatchMaker::Base do
 
   describe '#matches?' do
     it 'raises an error if no @match_definition is set' do
-      expect { matcher.matches?(target) }.to raise_error JsonRspecMatchMaker::MatchDefinitionNotFound
+      expect { matcher.matches?(target) }.to(
+        raise_error JsonRspecMatchMaker::MatchDefinitionNotFound
+      )
     end
   end
 

--- a/spec/lib/json_rspec_match_maker/base_spec.rb
+++ b/spec/lib/json_rspec_match_maker/base_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe JsonRspecMatchMaker::Base do
   Struct.new('Example', :id, :name, :description)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,16 @@
 require 'json_rspec_match_maker'
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  config.order = :random
+  config.filter_run_when_matching :focus
+end

--- a/spec/subclass_matcher_spec.rb
+++ b/spec/subclass_matcher_spec.rb
@@ -1,32 +1,44 @@
 require 'spec_helper'
 
-Struct.new('Associated', :id, :description)
-test_associated = Struct::Associated.new(2, 'An associated record')
+Struct.new('SingleAssociated', :id, :type)
+test_single_associated = Struct::SingleAssociated.new(3, :foo)
 
-Struct.new('Instance', :id, :name, :association)
-test_instance = Struct::Instance.new(1, 'test', [test_associated])
+Struct.new('ManyAssociated', :id, :description, :something_else)
+test_many_associated = Struct::ManyAssociated.new(
+  2, 'An associated record in a list', test_single_associated
+)
+
+class TestInstance
+  attr_reader :id, :first_name, :last_name, :many_association, :single_association
+
+  def initialize(id, first_name, last_name, many_association, single_association)
+    @id = id
+    @first_name = first_name
+    @last_name = last_name
+    @many_association = [many_association]
+    @single_association = single_association
+  end
+
+  def full_name
+    [first_name, last_name].join(' ')
+  end
+end
+test_instance =
+  TestInstance.new(1, 'John', 'Johnson', test_many_associated, test_single_associated)
 
 class ExampleMatcher < JsonRspecMatchMaker::Base
   MATCH_DEF = {
-    'id' => {
-      instance: ->(instance) { instance.id },
-      json: ->(json) { json['id'] }
-    },
-    'name' => {
-      instance: ->(instance) { instance.name },
-      json: ->(json) { json['name'] }
-    },
-    'association' => {
-      each_with_index: ->(instance) { instance.association },
+    'id' => ->(instance) { instance.id },
+    'name' => ->(instance) { instance.full_name },
+    'single_association.id' => ->(instance) { instance.single_association.id },
+    'single_association.type' => ->(instance) { instance.single_association.type },
+    'many_association' => {
+      each: ->(instance) { instance.many_association },
       attributes: {
-        'id' => {
-          instance: ->(instance) { instance.id },
-          json: ->(json, idx) { json['association'][idx]['id'] }
-        },
-        'description' => {
-          instance: ->(instance) { instance.description },
-          json: ->(json, idx) { json['association'][idx]['description'] }
-        }
+        'id' => ->(each_instance) { each_instance.id },
+        'description' => ->(each_instance) { each_instance.description },
+        'something_else.id' => ->(each_instance) { each_instance.something_else.id },
+        'something_else.type' => ->(each_instance) { each_instance.something_else.type }
       }
     }
   }.freeze
@@ -37,30 +49,42 @@ class ExampleMatcher < JsonRspecMatchMaker::Base
   end
 end
 
-matching_json = {
-  'id' => test_instance.id,
-  'name' => test_instance.name,
-  'association' => [
-    {
-      'id' => test_associated.id,
-      'description' => test_associated.description
-    }
-  ]
-}
-
-mismatching_json = {
-  'id' => test_instance.id,
-  'name' => 'Not Name',
-  'association' => [
-    {
-      'id' => test_associated.id,
-      'description' => test_associated.description
-    }
-  ]
-}
-
+# rubocop:disable Metrics/BlockLength
 RSpec.describe 'Subclass Matcher' do
   let(:matcher) { ExampleMatcher.new(test_instance) }
+
+  let(:matching_json) do
+    {
+      'id' => test_instance.id,
+      'name' => test_instance.full_name,
+      'single_association' => {
+        'id' => test_single_associated.id,
+        'type' => test_single_associated.type
+      },
+      'many_association' => [
+        {
+          'id' => test_many_associated.id,
+          'description' => test_many_associated.description,
+          'something_else' => {
+            'id' => test_single_associated.id,
+            'type' => test_single_associated.type
+          }
+        }
+      ]
+    }
+  end
+
+  let(:mismatching_json_single) do
+    matching_json.dup.tap do |json|
+      json['name'] = 'John Johnson '
+    end
+  end
+
+  let(:mismatching_json_many) do
+    matching_json.dup.tap do |json|
+      json['many_association'][0]['description'] = 'Nonsense'
+    end
+  end
 
   describe 'matches?' do
     it 'returns true for matching json' do
@@ -68,11 +92,22 @@ RSpec.describe 'Subclass Matcher' do
     end
 
     it 'returns false for mismatching json' do
-      expect(matcher.matches?(mismatching_json)).to eq false
+      expect(matcher.matches?(mismatching_json_single)).to eq false
 
       expect(matcher.failure_message).to(
-        eq 'Mismatch in field name: expected (test), got: (Not Name)'
+        eq 'Mismatch in field name: expected (John Johnson), got: (John Johnson )'
+      )
+    end
+
+    it 'returns error messages for each errors' do
+      expect(matcher.matches?(mismatching_json_many)).to eq false
+
+      field_name = 'many_association[0].description'
+      description = 'An associated record in a list'
+      expect(matcher.failure_message).to(
+        eq "Mismatch in field #{field_name}: expected (#{description}), got: (Nonsense)"
       )
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/subclass_matcher_spec.rb
+++ b/spec/subclass_matcher_spec.rb
@@ -94,8 +94,15 @@ RSpec.describe 'Subclass Matcher' do
     it 'returns false for mismatching json' do
       expect(matcher.matches?(mismatching_json_single)).to eq false
 
+      # rubocop:disable Layout/EmptyLinesAroundArguments
       expect(matcher.failure_message).to(
-        eq 'Mismatch in field name: expected (John Johnson), got: (John Johnson )'
+        eq <<-MSG
+
+        Mismatch in field: 'name'
+          expected: 'John Johnson'
+          received: 'John Johnson '
+
+        MSG
       )
     end
 
@@ -105,8 +112,15 @@ RSpec.describe 'Subclass Matcher' do
       field_name = 'many_association[0].description'
       description = 'An associated record in a list'
       expect(matcher.failure_message).to(
-        eq "Mismatch in field #{field_name}: expected (#{description}), got: (Nonsense)"
+        eq <<-MSG
+
+        Mismatch in field: '#{field_name}'
+          expected: '#{description}'
+          received: 'Nonsense'
+
+        MSG
       )
+      # rubocop:enable Layout/EmptyLinesAroundArguments
     end
   end
 end

--- a/spec/subclass_matcher_spec.rb
+++ b/spec/subclass_matcher_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 Struct.new('SingleAssociated', :id, :type)
 test_single_associated = Struct::SingleAssociated.new(3, :foo)
 


### PR DESCRIPTION
- changed names of things being checked to `expected` and `target` to
confirm with RSpec naming
- Removed unecessary json matching functions - now inferred from key
names
- support single nested keys at any depth
  - e.g. this.key.things[0].other.key
- Added more specs